### PR TITLE
Arm64 support and CI improvement

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Build and push image image
         run: |
           if [ -z "${{ env.image_tag }}" ]; then
-              docker buildx build . --file Dockerfile --tag ${{ env.image_tag }} --platform linux/amd64,linux/arm64 --push
-          else
               docker buildx build . --file Dockerfile --tag $IMAGE_NAME --platform linux/amd64,linux/arm64
+          else
+              docker buildx build . --file Dockerfile --tag ${{ env.image_tag }} --platform linux/amd64,linux/arm64 --push
           fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,7 +4,6 @@ on:
   push:
 
 env:
-  # TODO: Change variable to your image's name.
   IMAGE_NAME: terminusdb/swipl
 
 jobs:
@@ -29,9 +28,6 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
 
-      - name: Build image
-        run: docker buildx build . --file Dockerfile --tag $IMAGE_NAME --platform linux/amd64,linux/arm64
-
       - name: Log into registry
         if: >
           github.event_name == 'push' && (
@@ -40,7 +36,7 @@ jobs:
           )
         run:  echo '${{ secrets.DOCKER_PASS }}' | docker login -u terminusdb --password-stdin
 
-      - name: Push image
+      - name: Set image name
         if: >
           github.event_name == 'push' && (
             github.ref == 'refs/heads/master' ||
@@ -58,8 +54,12 @@ jobs:
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
 
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
+          echo "image_tag=${IMAGE_ID}:${VERSION}" >> $GITHUB_ENV
 
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+      - name: Build and push image image
+        run: |
+          if [ -z ${{ env.image_tag }} ]; then
+              docker buildx build . --file Dockerfile --tag ${{ env.image_tag }} --platform linux/amd64,linux/arm64 --push
+          else
+              docker buildx build . --file Dockerfile --tag $IMAGE_NAME --platform linux/amd64,linux/arm64
+          fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build and push image image
         run: |
-          if [ -z ${{ env.image_tag }} ]; then
+          if [ -z "${{ env.image_tag }}" ]; then
               docker buildx build . --file Dockerfile --tag ${{ env.image_tag }} --platform linux/amd64,linux/arm64 --push
           else
               docker buildx build . --file Dockerfile --tag $IMAGE_NAME --platform linux/amd64,linux/arm64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Build image
-        run: docker buildx build . --file Dockerfile --tag $IMAGE_NAME
+        run: docker buildx build . --file Dockerfile --tag $IMAGE_NAME --platform linux/amd64,linux/arm64
 
       - name: Log into registry
         if: >

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,13 +2,6 @@ name: Docker
 
 on:
   push:
-    # Publish `master` as Docker `latest` image.
-    branches:
-      - master
-
-    # Publish `v1.2.3` tags as releases.
-    tags:
-      - v*
 
 env:
   # TODO: Change variable to your image's name.
@@ -23,15 +16,36 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+
+        # Add support for more platforms with QEMU (optional)
+        # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+        run: docker buildx build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into registry
+        if: >
+          github.event_name == 'push' && (
+            github.ref == 'refs/heads/master' ||
+            startsWith(github.ref, 'refs/tags/v')
+          )
         run:  echo '${{ secrets.DOCKER_PASS }}' | docker login -u terminusdb --password-stdin
 
       - name: Push image
+        if: >
+          github.event_name == 'push' && (
+            github.ref == 'refs/heads/master' ||
+            startsWith(github.ref, 'refs/tags/v')
+          )
         run: |
           IMAGE_ID=$IMAGE_NAME
 


### PR DESCRIPTION
Add an ARM64 version of our swipl image. Also build the Docker on every commit because we want to know before publishing whether the commits work correctly in PRs and the like.